### PR TITLE
Add page size selector to search results

### DIFF
--- a/src/components/search/PageSizeSelector.tsx
+++ b/src/components/search/PageSizeSelector.tsx
@@ -1,0 +1,121 @@
+import { useState, useRef, useEffect } from "react";
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
+
+interface PageSizeSelectorProps {
+  currentPageSize: number;
+  onPageSizeChange: (size: number) => void;
+  totalCount: number;
+}
+
+const PAGE_SIZE_OPTIONS = [
+  { value: 12, label: "12 per page" },
+  { value: 24, label: "24 per page" },
+  { value: 48, label: "48 per page" },
+  { value: 96, label: "96 per page" },
+];
+
+function PageSizeSelector({
+  currentPageSize,
+  onPageSizeChange,
+  totalCount,
+}: PageSizeSelectorProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  const getCurrentLabel = () => {
+    const option = PAGE_SIZE_OPTIONS.find(
+      (opt) => opt.value === currentPageSize
+    );
+    return option ? option.label : `${currentPageSize} per page`;
+  };
+
+  const handleOptionClick = (value: number) => {
+    onPageSizeChange(value);
+    setIsOpen(false);
+  };
+
+  const toggleDropdown = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={toggleDropdown}
+        className={`
+          inline-flex items-center px-3 py-2 rounded-md border text-sm font-medium
+          transition-all duration-200 min-w-0
+          ${
+            isOpen
+              ? "border-primary-500 bg-primary-50 text-primary-700 shadow-sm"
+              : "border-gray-300 bg-white text-gray-700 hover:border-gray-400 hover:bg-gray-50"
+          }
+        `}
+      >
+        <span className="mr-2 truncate">{getCurrentLabel()}</span>
+        <ChevronDownIcon
+          className={`h-4 w-4 transition-transform duration-200 flex-shrink-0 ${
+            isOpen ? "transform rotate-180" : ""
+          }`}
+        />
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-full right-0 mt-2 w-40 bg-white rounded-md shadow-lg border border-gray-200 z-50">
+          <div className="py-1">
+            <div className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wide border-b border-gray-100">
+              Show
+            </div>
+            {PAGE_SIZE_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                onClick={() => handleOptionClick(option.value)}
+                disabled={option.value > totalCount && totalCount > 0}
+                className={`
+                  w-full text-left px-3 py-2 text-sm transition-colors duration-150
+                  ${
+                    currentPageSize === option.value
+                      ? "bg-primary-50 text-primary-700 font-medium"
+                      : option.value > totalCount && totalCount > 0
+                      ? "text-gray-400 cursor-not-allowed"
+                      : "text-gray-700 hover:bg-gray-50"
+                  }
+                `}
+              >
+                <div className="flex items-center justify-between">
+                  <span>{option.label}</span>
+                  {currentPageSize === option.value && (
+                    <div className="w-2 h-2 bg-primary-500 rounded-full"></div>
+                  )}
+                  {option.value > totalCount && totalCount > 0 && (
+                    <span className="text-xs text-gray-400">
+                      (only {totalCount})
+                    </span>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default PageSizeSelector;

--- a/src/components/search/SortControls.tsx
+++ b/src/components/search/SortControls.tsx
@@ -50,7 +50,7 @@ function SortControls({ currentSort, onSortChange }: SortControlsProps) {
   };
 
   return (
-    <div className="relative mb-8" ref={dropdownRef}>
+    <div className="relative" ref={dropdownRef}>
       <button
         onClick={toggleDropdown}
         className={`

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -24,8 +24,10 @@ interface UseSearchReturn {
 
   selectedBreeds: string[];
   currentSort: string;
+  currentPageSize: number;
   setSelectedBreeds: (breeds: string[]) => void;
   setCurrentSort: (sort: string) => void;
+  setCurrentPageSize: (size: number) => void;
 }
 
 export function useSearch(options: UseSearchOptions = {}): UseSearchReturn {
@@ -38,6 +40,7 @@ export function useSearch(options: UseSearchOptions = {}): UseSearchReturn {
 
   const [selectedBreeds, setSelectedBreeds] = useState<string[]>([]);
   const [currentSort, setCurrentSort] = useState<string>(initialSort);
+  const [currentPageSize, setCurrentPageSize] = useState<number>(initialSize);
 
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [matchingDogCount, setMatchingDogCount] = useState<number>(0);
@@ -55,7 +58,7 @@ export function useSearch(options: UseSearchOptions = {}): UseSearchReturn {
 
       try {
         const searchParams: DogSearchParams = {
-          size: isInitialSearch ? initialSize : 25,
+          size: currentPageSize,
           sort: currentSort,
         };
 
@@ -111,7 +114,7 @@ export function useSearch(options: UseSearchOptions = {}): UseSearchReturn {
         }
       }
     },
-    [selectedBreeds, currentSort, initialSize, nextCursor]
+    [selectedBreeds, currentSort, currentPageSize, nextCursor]
   );
 
   const loadMoreDogs = useCallback(async () => {
@@ -131,7 +134,7 @@ export function useSearch(options: UseSearchOptions = {}): UseSearchReturn {
 
   useEffect(() => {
     refreshSearch();
-  }, [selectedBreeds, currentSort]);
+  }, [selectedBreeds, currentSort, currentPageSize]);
 
   const handleSetSelectedBreeds = useCallback((breeds: string[]) => {
     setSelectedBreeds(breeds);
@@ -139,6 +142,10 @@ export function useSearch(options: UseSearchOptions = {}): UseSearchReturn {
 
   const handleSetCurrentSort = useCallback((sort: string) => {
     setCurrentSort(sort);
+  }, []);
+
+  const handleSetCurrentPageSize = useCallback((size: number) => {
+    setCurrentPageSize(size);
   }, []);
 
   return {
@@ -156,7 +163,9 @@ export function useSearch(options: UseSearchOptions = {}): UseSearchReturn {
 
     selectedBreeds,
     currentSort,
+    currentPageSize,
     setSelectedBreeds: handleSetSelectedBreeds,
     setCurrentSort: handleSetCurrentSort,
+    setCurrentPageSize: handleSetCurrentPageSize,
   };
 }

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -6,6 +6,7 @@ import DogCard from "../components/dogs/DogCard";
 import Spinner from "../components/ui/Spinner";
 import SearchBar from "../components/search/SearchBar";
 import SortControls from "../components/search/SortControls";
+import PageSizeSelector from "../components/search/PageSizeSelector";
 import LoadMoreButton from "../components/search/LoadMoreButton";
 
 function SearchPage() {
@@ -22,8 +23,10 @@ function SearchPage() {
     loadMoreDogs,
     selectedBreeds,
     currentSort,
+    currentPageSize,
     setSelectedBreeds,
     setCurrentSort,
+    setCurrentPageSize,
   } = useSearch({
     initialSize: 24,
     initialSort: "breed:asc",
@@ -51,7 +54,25 @@ function SearchPage() {
           onBreedsChange={setSelectedBreeds}
         />
 
-        <SortControls currentSort={currentSort} onSortChange={setCurrentSort} />
+        <div className="flex justify-between items-center mb-8">
+          <SortControls
+            currentSort={currentSort}
+            onSortChange={setCurrentSort}
+          />
+
+          <div className="flex items-center space-x-4">
+            <span className="text-sm text-gray-600">
+              {loading
+                ? "Loading..."
+                : `Showing ${displayedDogs.length} of ${matchingDogCount} dogs`}
+            </span>
+            <PageSizeSelector
+              currentPageSize={currentPageSize}
+              onPageSizeChange={setCurrentPageSize}
+              totalCount={matchingDogCount}
+            />
+          </div>
+        </div>
 
         <div className="bg-white rounded-lg shadow-md p-6">
           {loading ? (


### PR DESCRIPTION
This PR adds a configurable page size selector to the search page, allowing users to choose how many dogs to display per page (12, 24, 48, or 96 options).

Changes Made
- New Component: PageSizeSelector - Dropdown component with page size options
- Enhanced Hook: Updated useSearch hook to support dynamic page sizes
- Updated Search Page: Added page size selector alongside sort controls with results counter