### PR TITLE
Replace direct DOM manipulation in Modal with reusable useBodyScrollLock hook

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import type { ReactNode } from "react";
+import { useBodyScrollLock } from "../../hooks/useBodyScrollLock";
 
 interface ModalProps {
   isOpen: boolean;
@@ -33,17 +34,7 @@ function Modal({
     };
   }, [isOpen, onClose, closeOnEscape]);
 
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "unset";
-    }
-
-    return () => {
-      document.body.style.overflow = "unset";
-    };
-  }, [isOpen]);
+  useBodyScrollLock({ isActive: isOpen });
 
   if (!isOpen) return null;
 

--- a/src/hooks/useBodyScrollLock.ts
+++ b/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+
+interface UseBodyScrollLockOptions {
+  isActive: boolean;
+}
+
+export function useBodyScrollLock({
+  isActive,
+}: UseBodyScrollLockOptions): void {
+  useEffect(() => {
+    if (!isActive) return;
+
+    const originalOverflowStyle = lockBodyScroll();
+    return () => unlockBodyScroll(originalOverflowStyle);
+  }, [isActive]);
+}
+
+function lockBodyScroll(): string {
+  const originalStyle = window.getComputedStyle(document.body).overflow;
+  const currentLocks = parseInt(document.body.dataset.scrollLocks || "0", 10);
+
+  document.body.style.overflow = "hidden";
+  document.body.dataset.scrollLocks = String(currentLocks + 1);
+
+  return originalStyle;
+}
+
+function unlockBodyScroll(originalStyle: string): void {
+  const locks = parseInt(document.body.dataset.scrollLocks || "0", 10);
+
+  if (locks <= 1) {
+    document.body.style.overflow = originalStyle;
+    delete document.body.dataset.scrollLocks;
+  } else {
+    document.body.dataset.scrollLocks = String(locks - 1);
+  }
+}


### PR DESCRIPTION
This PR refactors direct document.body.style.overflow manipulation into a reusable React hook that properly handles multiple concurrent modals and follows React best practices.